### PR TITLE
Stream processing support in common actors

### DIFF
--- a/ractor_actors/Cargo.toml
+++ b/ractor_actors/Cargo.toml
@@ -16,8 +16,9 @@ categories = ["actor", "erlang"]
 filewatcher = ["notify"]
 net = ["tokio/net", "tokio/io-util", "tokio/macros", "tokio-rustls"]
 time = ["chrono", "cron"]
+streams = ["tokio-stream"]
 
-default = ["filewatcher", "net", "time"]
+default = ["filewatcher", "net", "time", "streams"]
 
 [dependencies]
 # Required dependencies
@@ -27,6 +28,7 @@ tracing = "0.1"
 # Feature-specific dependencies
 chrono = { version = "0.4", optional = true }
 cron = { version = "0.12", optional = true }
+tokio-stream = { version = "0.1", optional = true }
 notify = { version = "5", optional = true }
 tokio-rustls = { version = "0.23", optional = true }
 

--- a/ractor_actors/Cargo.toml
+++ b/ractor_actors/Cargo.toml
@@ -36,3 +36,4 @@ tokio-rustls = { version = "0.23", optional = true }
 tokio = { version = "1", features = ["rt", "time", "sync", "macros", "rt-multi-thread", "signal"] }
 tracing-glog = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"]}
+tracing-test = "0.2"

--- a/ractor_actors/src/common_test.rs
+++ b/ractor_actors/src/common_test.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::future::Future;
+
+use ractor::concurrency::sleep;
+use ractor::concurrency::Duration;
+use ractor::concurrency::Instant;
+
+pub async fn periodic_check<F>(check: F, timeout: Duration)
+where
+    F: Fn() -> bool,
+{
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if check() {
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert!(check());
+}
+
+pub async fn periodic_async_check<F, Fut>(check: F, timeout: Duration)
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if check().await {
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    assert!(check().await);
+}

--- a/ractor_actors/src/filewatcher/tests.rs
+++ b/ractor_actors/src/filewatcher/tests.rs
@@ -10,8 +10,10 @@ use std::sync::{Arc, Mutex};
 use ractor::concurrency::{test as rtest, Duration};
 
 use super::*;
+use crate::common_test::periodic_check;
 
 #[rtest]
+#[tracing_test::traced_test]
 async fn filewatcher_starts_default_config() {
     // Setup
     let fw = FileWatcher;
@@ -28,6 +30,7 @@ async fn filewatcher_starts_default_config() {
 }
 
 #[rtest]
+#[tracing_test::traced_test]
 async fn filewatch_watches_file() {
     // Setup
     let mut dir = temp_dir();
@@ -86,9 +89,7 @@ async fn filewatch_watches_file() {
     write!(file, "Some data").expect("Failed to write to file");
     drop(file); // close out the file
 
-    ractor::concurrency::sleep(Duration::from_millis(200)).await;
-
-    assert!(events.lock().unwrap().len() >= 1);
+    periodic_check(|| events.lock().unwrap().len() >= 1, Duration::from_secs(3)).await;
 
     // Cleanup
     fwactor.stop(None);

--- a/ractor_actors/src/lib.rs
+++ b/ractor_actors/src/lib.rs
@@ -41,3 +41,6 @@ pub mod net;
 
 #[cfg(feature = "time")]
 pub mod time;
+
+#[cfg(feature = "streams")]
+pub mod streams;

--- a/ractor_actors/src/lib.rs
+++ b/ractor_actors/src/lib.rs
@@ -44,3 +44,6 @@ pub mod time;
 
 #[cfg(feature = "streams")]
 pub mod streams;
+
+#[cfg(test)]
+pub(crate) mod common_test;

--- a/ractor_actors/src/streams/looping/mod.rs
+++ b/ractor_actors/src/streams/looping/mod.rs
@@ -1,0 +1,149 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! An actor which wraps an operation that should be done in a looped fashion.
+//! This actor continually executes the operation in an infinite basis until
+//! the operation either signals it's complete or throws an error.
+//!
+//! To keep dependent services agnostic to the underlying actor logic, you can simply
+//! use [spawn_loop] to start an operation which should be done in a loop.
+//!
+//! ```
+//! use ractor::ActorProcessingErr;
+//! use ractor::concurrency::Duration;
+//! use ractor::concurrency::sleep;
+//! use ractor_actors::streams::looping::{Operation, IterationResult, spawn_loop};
+//!
+//! struct SampleOperation;
+//!
+//! #[ractor::async_trait]
+//! impl Operation for SampleOperation {
+//!     type State = ();
+//!
+//!     async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr> {
+//!         println!("I'm a loop!");
+//!         sleep(Duration::from_millis(25)).await;
+//!         Ok(IterationResult::Continue)
+//!     }
+//! }
+//! let _ = async {
+//!     let _actor = spawn_loop(SampleOperation, (), None).await.expect("Failed to start sample");
+//! };
+//! ```
+
+use std::marker::PhantomData;
+
+use ractor::cast;
+use ractor::Actor;
+use ractor::ActorCell;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+use ractor::SpawnErr;
+
+#[cfg(test)]
+mod tests;
+
+/// Represents the result of a looping operation. It signals if the
+/// loop operation is should continue or end.
+pub enum IterationResult {
+    /// There's more to process, keep looping
+    Continue,
+    /// We're reached the end of the loop, stop processing
+    End,
+}
+
+/// An operation is an implementation which is repeatedly called, blocking the task, until
+/// either (a) shutdown ([IterationResult::End]) or (b) error. This could be processing a stream
+/// request or some continuous polling operation (something like a configuration element,
+/// which emits signals when the config changes)
+#[ractor::async_trait]
+pub trait Operation: ractor::State + Sync {
+    /// The state of the looping operation. It is bound to the internal actor's [Actor::State]
+    /// but doesn't require specifying all of the inner actor properties
+    type State: ractor::State;
+
+    /// Do this loop's worth of work. Returning a signal if there's more loop processing to do
+    /// or we should stop processing
+    async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr>;
+}
+
+/// A blocking actor which performs a given async operation continually
+/// in a loop and does not handle external messages. It is strongly typed
+/// to the inner implementation of the [Operation] that it's looping on.
+struct Loop<T>
+where
+    T: Operation,
+{
+    _t: PhantomData<T>,
+}
+
+// SAFETY: `T` is only present as PhantomData, so it doesn't actually affect if the
+// [LoopActor] is Sync across thread boundaries.
+unsafe impl<T> Sync for Loop<T> where T: Operation {}
+
+#[ractor::async_trait]
+impl<TOperation> Actor for Loop<TOperation>
+where
+    TOperation: Operation,
+{
+    type Msg = ();
+    type State = (TOperation, TOperation::State);
+    type Arguments = (TOperation, TOperation::State);
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<()>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // start the loop operation
+        cast!(myself, ())?;
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<()>,
+        _: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // perform the operation
+        let result = state.0.work(&mut state.1).await?;
+        if let IterationResult::Continue = result {
+            cast!(myself, ())?;
+        } else {
+            myself.stop(None);
+        }
+        Ok(())
+    }
+}
+
+/// Spawn an operation which will continue executing until either
+///
+/// 1. One of the operation calls panics or returns an error
+/// 2. The operation signals it's completed with [IterationResult::End]
+///
+/// The loop operation additionally can thread a state which can be used in loop operations.
+///
+/// * `op`: The [Operation] implementation defining the work at each loop iteration
+/// * `istate`: The initial state for the loop operation
+/// * `supervisor`: (Optional) The [ActorCell] supervisor actor which will supervise the underlying loop operation actor
+///
+/// Returns [Ok(ActorCell)] if the underlying actor was successfully spawned, [SpawnErr] if a startup failure occurs.
+pub async fn spawn_loop<TOperation>(
+    op: TOperation,
+    istate: TOperation::State,
+    supervisor: Option<ActorCell>,
+) -> Result<ActorCell, SpawnErr>
+where
+    TOperation: Operation,
+{
+    let actor = Loop { _t: PhantomData };
+    let actor_ref = if let Some(sup) = supervisor {
+        Actor::spawn_linked(None, actor, (op, istate), sup).await?.0
+    } else {
+        Actor::spawn(None, actor, (op, istate)).await?.0
+    };
+    Ok(actor_ref.into())
+}

--- a/ractor_actors/src/streams/looping/tests.rs
+++ b/ractor_actors/src/streams/looping/tests.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use ractor::call;
+use ractor::concurrency::sleep;
+use ractor::concurrency::Duration;
+use ractor::RpcReplyPort;
+
+use super::*;
+
+struct BackgroundAdder;
+
+#[ractor::async_trait]
+impl Operation for BackgroundAdder {
+    type State = ActorRef<TestBedMessage>;
+
+    async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr> {
+        cast!(state, TestBedMessage::Add(1))?;
+        sleep(Duration::from_millis(25)).await;
+        Ok(IterationResult::Continue)
+    }
+}
+
+struct TestBedActor;
+
+enum TestBedMessage {
+    GetCount(RpcReplyPort<u64>),
+    Add(u64),
+}
+
+#[ractor::async_trait]
+impl Actor for TestBedActor {
+    type Msg = TestBedMessage;
+    type State = u64;
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        _: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // just for the test, drop the cell
+        let _ = super::spawn_loop(BackgroundAdder, myself.clone(), Some(myself.get_cell())).await?;
+
+        Ok(0)
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            TestBedMessage::GetCount(reply) => {
+                let _ = reply.send(*state);
+            }
+            TestBedMessage::Add(i) => {
+                *state += i;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[ractor::concurrency::test]
+async fn test_looping_operation() {
+    // Setup
+    // Create the actor
+    let (actor, handle) = Actor::spawn(None, TestBedActor, ())
+        .await
+        .expect("Failed to spawn non-blocking actor tree");
+
+    // Allow the background blocking operation some time to increment the parent's counter
+    sleep(Duration::from_millis(100)).await;
+
+    // Assert
+
+    // Get the count
+    let reply = call!(actor, TestBedMessage::GetCount).expect("Failed to get count");
+    assert!(reply >= 3);
+
+    // Cleanup
+    actor.stop(None);
+    handle.await.unwrap();
+}

--- a/ractor_actors/src/streams/mod.rs
+++ b/ractor_actors/src/streams/mod.rs
@@ -5,133 +5,13 @@
 
 //! Streaming utilities built off of [ractor] actors. This includes building a looped
 //! operation (see [looping]) and actors which process streams.
-//!
-//! ## Processing a stream
-//!
-//! If you want to process a stream which emits records that should
-//! be forwarded to an actor for processing, you can utilize [spawn_stream_pump]
-//! to create an actor which will specifically process a stream of messages and
-//! convert them to messages for an actor, pushing them into the actor's message queue.
-//!
-//! We specifically don't expose the internals of how the stream pump actor is created,
-//! but still support monitoring the actor by returning an [ActorCell] which represents
-//! the underlying actor, and can be used for pattern matching on supervision events.
 
 pub mod looping;
-
-use std::marker::PhantomData;
-use std::pin::Pin;
-
-use ractor::cast;
-use ractor::ActorCell;
-use ractor::ActorProcessingErr;
-use ractor::ActorRef;
-use ractor::SpawnErr;
-use tokio_stream::Stream;
-use tokio_stream::StreamExt;
-
-#[cfg(test)]
-mod tests;
-
-struct StreamerState<S, T, F>
-where
-    S: Stream + ractor::State,
-    T: ractor::Message,
-    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
-{
-    stream: Pin<Box<S>>,
-    fn_map: F,
-    who: ActorRef<T>,
-}
-
-struct Streamer<S, T, F>
-where
-    S: Stream + ractor::State,
-    T: ractor::Message,
-    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
-{
-    _s: PhantomData<S>,
-    _t: PhantomData<T>,
-    _f: PhantomData<F>,
-}
-
-// SAFETY: The types here are all phantom data markers, and do not impact
-// the requirement for streamer to be Sync
-unsafe impl<S, T, F> Sync for Streamer<S, T, F>
-where
-    S: Stream + ractor::State,
-    T: ractor::Message,
-    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
-{
-}
-
-#[ractor::async_trait]
-impl<S, T, F> Operation for Streamer<S, T, F>
-where
-    S: Stream + ractor::State,
-    T: ractor::Message,
-    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
-{
-    type State = StreamerState<S, T, F>;
-
-    async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr> {
-        // fetch the next item and check if it's the last item
-        let item = state.stream.next().await;
-        let last = item.is_none();
-
-        tracing::trace!("Streamer forwarding item: last {last}");
-
-        cast!(state.who, (state.fn_map)(item))?;
-
-        let signal = if last {
-            IterationResult::End
-        } else {
-            IterationResult::Continue
-        };
-        Ok(signal)
-    }
-}
-
-/// Process a stream of information, pumping messages received to a receipient
-///
-/// * `stream`: The stream of `Item`s to process
-/// * `receiver`: The actor who will receive outputs from the stream
-/// * `fn_map`: Mapping function to convert a `S::Item` to the input message for the recipient actor.
-/// In the event the stream type is a sub-value of the message enum of the actor, this can be used
-/// to map to the right sub-message type
-/// * `supervisor`: (Optional) If the receiver is **not** the supervisor, a separate supervisor can be
-/// provided here
-///
-/// Returns the [ActorCell] for the underlying stream pump actor upon successful startup, or a [SpawnErr] if the
-/// underlying actor failed to spawn.
-pub async fn spawn_stream_pump<S, T, F>(
-    stream: S,
-    receiver: ActorRef<T>,
-    fn_map: F,
-    supervisor: Option<ActorCell>,
-) -> Result<ActorCell, SpawnErr>
-where
-    S: Stream + ractor::State,
-    T: ractor::Message,
-    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
-{
-    let sup = supervisor.unwrap_or_else(|| receiver.get_cell());
-
-    let pumper = Streamer::<S, T, F> {
-        _s: PhantomData,
-        _t: PhantomData,
-        _f: PhantomData,
-    };
-    let pump_state = StreamerState::<S, T, F> {
-        fn_map,
-        who: receiver,
-        stream: Box::pin(stream),
-    };
-
-    spawn_loop(pumper, pump_state, Some(sup)).await
-}
+pub mod mux;
+pub mod pump;
 
 // Re-exports
 pub use looping::spawn_loop;
 pub use looping::IterationResult;
 pub use looping::Operation;
+pub use pump::spawn_stream_pump;

--- a/ractor_actors/src/streams/mod.rs
+++ b/ractor_actors/src/streams/mod.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! Streaming utilities built off of [ractor] actors. This includes building a looped
+//! operation (see [looping]) and actors which process streams.
+//!
+//! ## Processing a stream
+//!
+//! If you want to process a stream which emits records that should
+//! be forwarded to an actor for processing, you can utilize [spawn_stream_pump]
+//! to create an actor which will specifically process a stream of messages and
+//! convert them to messages for an actor, pushing them into the actor's message queue.
+//!
+//! We specifically don't expose the internals of how the stream pump actor is created,
+//! but still support monitoring the actor by returning an [ActorCell] which represents
+//! the underlying actor, and can be used for pattern matching on supervision events.
+
+pub mod looping;
+
+use std::marker::PhantomData;
+use std::pin::Pin;
+
+use ractor::cast;
+use ractor::ActorCell;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+use ractor::SpawnErr;
+use tokio_stream::Stream;
+use tokio_stream::StreamExt;
+
+#[cfg(test)]
+mod tests;
+
+struct StreamerState<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    stream: Pin<Box<S>>,
+    fn_map: F,
+    who: ActorRef<T>,
+}
+
+struct Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    _s: PhantomData<S>,
+    _t: PhantomData<T>,
+    _f: PhantomData<F>,
+}
+
+// SAFETY: The types here are all phantom data markers, and do not impact
+// the requirement for streamer to be Sync
+unsafe impl<S, T, F> Sync for Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+}
+
+#[ractor::async_trait]
+impl<S, T, F> Operation for Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    type State = StreamerState<S, T, F>;
+
+    async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr> {
+        // fetch the next item and check if it's the last item
+        let item = state.stream.next().await;
+        let last = item.is_none();
+
+        tracing::trace!("Streamer forwarding item: last {last}");
+
+        cast!(state.who, (state.fn_map)(item))?;
+
+        let signal = if last {
+            IterationResult::End
+        } else {
+            IterationResult::Continue
+        };
+        Ok(signal)
+    }
+}
+
+/// Process a stream of information, pumping messages received to a receipient
+///
+/// * `stream`: The stream of `Item`s to process
+/// * `receiver`: The actor who will receive outputs from the stream
+/// * `fn_map`: Mapping function to convert a `S::Item` to the input message for the recipient actor.
+/// In the event the stream type is a sub-value of the message enum of the actor, this can be used
+/// to map to the right sub-message type
+/// * `supervisor`: (Optional) If the receiver is **not** the supervisor, a separate supervisor can be
+/// provided here
+///
+/// Returns the [ActorCell] for the underlying stream pump actor upon successful startup, or a [SpawnErr] if the
+/// underlying actor failed to spawn.
+pub async fn spawn_stream_pump<S, T, F>(
+    stream: S,
+    receiver: ActorRef<T>,
+    fn_map: F,
+    supervisor: Option<ActorCell>,
+) -> Result<ActorCell, SpawnErr>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    let sup = supervisor.unwrap_or_else(|| receiver.get_cell());
+
+    let pumper = Streamer::<S, T, F> {
+        _s: PhantomData,
+        _t: PhantomData,
+        _f: PhantomData,
+    };
+    let pump_state = StreamerState::<S, T, F> {
+        fn_map,
+        who: receiver,
+        stream: Box::pin(stream),
+    };
+
+    spawn_loop(pumper, pump_state, Some(sup)).await
+}
+
+// Re-exports
+pub use looping::spawn_loop;
+pub use looping::IterationResult;
+pub use looping::Operation;

--- a/ractor_actors/src/streams/mux/mod.rs
+++ b/ractor_actors/src/streams/mux/mod.rs
@@ -1,0 +1,232 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! ## Stream multiplexing
+//!
+//! Multiplexing a stream to a collection of targets is a common "broadcast"
+//! operation. This actor supports taking an input stream and multiplexing the
+//! data on the stream to multiple targets, configured at runtime.
+//!
+//! The multiplexer
+//! 1. Takes a stream as input
+//! 2. Takes a series of targets as inputs as well
+//! 3. Use the stream pump to convert the stream to actor messages
+//! 4. If a target fails, it will remove the target, notify of the failure,
+//! and continue processing the stream for the other targets
+//! 5. Upon EOF for the stream, kill the actor cleanly, and cleanup downstream targets
+//!
+
+use std::{collections::HashSet, marker::PhantomData};
+
+use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, SpawnErr, SupervisionEvent};
+use tokio_stream::Stream;
+
+#[cfg(test)]
+mod tests;
+
+/// A callback which occurs when a downstream target cannot handle
+/// a stream item.
+pub trait StreamMuxNotification: 'static + Send {
+    /// Called when a target fails to process an item with an error.
+    ///
+    /// If this callback occurs for a target, the target will **NOT**
+    /// receive future items on the stream (we won't continue trying) if the
+    /// `stop_processing_target_on_failure` flag is [true]
+    fn target_failed(&self, target: String, err: ActorProcessingErr);
+
+    /// Called when the stream terminates, either from reacing the end
+    /// of the stream, or all targets failing and there being no more
+    /// downstream targets to send stream items to.
+    ///
+    /// The stream actor will also exit in the supervision flow, but if
+    /// you don't want to go through the supervision flow you can use
+    /// this to notify when the stream ends.
+    fn end_of_stream(&self);
+}
+
+/// A "target" of a stream's items. You can supply as many [Target]s
+/// as you wish for a given stream, and for each item received, each
+/// [Target] will receive a copy.
+pub trait Target<S>: 'static + Send
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+{
+    /// A unique id for this target, used for reporting. If it's an actor, this
+    /// can be the [ractor::ActorId] serialized to a string which is guaranteed to be
+    /// unique.
+    fn get_id(&self) -> String;
+    /// Called when an item is received. This is where downstream forwarding/handling may occur.
+    fn message_received(&self, item: <S as Stream>::Item) -> Result<(), ActorProcessingErr>;
+}
+
+/// Configuration for a stream multiplexing. This signifies the stream, where to send it,
+/// an informational callback, as well as processing control logic.
+pub struct StreamMuxConfiguration<S, N>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+    /// The stream to read items from
+    pub stream: S,
+    /// The collection of targets to forward the stream items to
+    pub targets: Vec<Box<dyn Target<S>>>,
+    /// The "informational callback" which is called when either a target
+    /// fails or the stream finishes. See [StreamMuxNotification] for more information
+    pub callback: N,
+    /// If [true], this signifies that we should stop processing future items for a given
+    /// [Target] upon the target returning an error handling an item. This can be used to
+    /// avoid [Target]s which are broken or continually having problems processing items.
+    pub stop_processing_target_on_failure: bool,
+}
+
+/// Mutiplex a stream to a collection of targets. Configured with a [StreamMuxConfiguration]
+/// which controlls the entire setting.
+///
+/// * `config` - The stream mutiplex configuration. See [StreamMuxConfiguration] for the full
+/// collection of arguments
+/// * `sup` - (Optional) The supervisor for the underlying actor. If you wish to use the supervision
+/// flow, this will connect the supervision flow for you
+///
+/// Returns [Ok(ActorCell)] signifying the underlying actor instance that was started upon successful
+/// start, [Err(SpawnErr)] if the actor fails to start (or the inner stream-pump fails to start).
+pub async fn mux_stream<S, N>(
+    config: StreamMuxConfiguration<S, N>,
+    sup: Option<ActorCell>,
+) -> Result<ActorCell, SpawnErr>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+    let handler = MuxActor::<S, N> {
+        _s: PhantomData,
+        _n: PhantomData,
+    };
+    let actor = if let Some(s) = sup {
+        Actor::spawn_linked(None, handler, config, s).await?.0
+    } else {
+        Actor::spawn(None, handler, config).await?.0
+    };
+
+    Ok(actor.into())
+}
+
+// --------------------------- Actor Implementation --------------------------- //
+struct MuxActorState<S, N>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+    targets: Vec<Box<dyn Target<S>>>,
+    callback: N,
+    stop_processing_target_on_failure: bool,
+    _pump: ActorCell,
+}
+
+/// Mux Actor
+struct MuxActor<S, N>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+    _s: PhantomData<S>,
+    _n: PhantomData<N>,
+}
+
+// SAFETY: The types here are all phantom data markers, and do not impact
+// the requirement for streamer to be Sync
+unsafe impl<S, N> Sync for MuxActor<S, N>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+}
+
+#[ractor::async_trait]
+impl<S, N> Actor for MuxActor<S, N>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+    N: StreamMuxNotification,
+{
+    type Msg = Option<S::Item>;
+    type State = MuxActorState<S, N>;
+    type Arguments = StreamMuxConfiguration<S, N>;
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        StreamMuxConfiguration::<S, N> {
+            stream,
+            targets,
+            callback,
+            stop_processing_target_on_failure,
+        }: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        let pump = crate::streams::spawn_stream_pump(stream, myself, |a| a, None).await?;
+        tracing::debug!("Stream pump started");
+        Ok(MuxActorState::<S, N> {
+            _pump: pump,
+            callback,
+            targets,
+            stop_processing_target_on_failure,
+        })
+    }
+
+    async fn handle(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: Option<S::Item>,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if let Some(item) = message {
+            let mut to_be_removed = HashSet::new();
+            for target in state.targets.iter() {
+                if let Err(err) = target.message_received(item.clone()) {
+                    let id = target.get_id();
+                    tracing::error!("Failed to send message to target {} with {err}", id);
+                    state.callback.target_failed(id.clone(), err);
+                    to_be_removed.insert(id);
+                }
+                // else successfully sent notification
+            }
+
+            if state.stop_processing_target_on_failure {
+                state
+                    .targets
+                    .retain(|target| !to_be_removed.contains(&target.get_id()));
+
+                if state.targets.is_empty() {
+                    tracing::debug!("Halting stream processing as no more targets exist");
+                    myself.stop(None);
+                    state.callback.end_of_stream();
+                }
+            }
+        } else {
+            myself.stop(Some("End of stream".to_string()));
+            state.callback.end_of_stream();
+            tracing::debug!("Reached end of stream");
+        }
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: SupervisionEvent,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        if let SupervisionEvent::ActorPanicked(_who, what) = message {
+            // bubble up panics, but not child exits (we may still be processing when the child stream pump stops)
+            return Err(ractor::ActorErr::Panic(what).into());
+        }
+        Ok(())
+    }
+}

--- a/ractor_actors/src/streams/mux/tests.rs
+++ b/ractor_actors/src/streams/mux/tests.rs
@@ -1,0 +1,209 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use std::{
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+};
+
+use ractor::concurrency::Duration;
+use ractor::ActorStatus;
+use tokio_stream::Iter;
+
+use super::*;
+use crate::common_test::periodic_check;
+
+// ================= Happy Path ================= //
+
+struct CounterTarget<S> {
+    idx: u16,
+    counter: Arc<AtomicU32>,
+    _s: PhantomData<S>,
+}
+
+impl<S> Target<S> for CounterTarget<S>
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+{
+    fn get_id(&self) -> String {
+        format!("{}", self.idx)
+    }
+
+    fn message_received(&self, _: <S as Stream>::Item) -> Result<(), ActorProcessingErr> {
+        self.counter.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+struct DummyCallback;
+
+impl StreamMuxNotification for DummyCallback {
+    fn target_failed(&self, _target: String, _err: ActorProcessingErr) {}
+    fn end_of_stream(&self) {}
+}
+
+#[ractor::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_mux_publishing() {
+    let counter = Arc::new(AtomicU32::new(0));
+
+    let targets: Vec<Box<dyn Target<Iter<std::ops::Range<u32>>>>> = vec![
+        Box::new(CounterTarget {
+            idx: 0,
+            counter: counter.clone(),
+            _s: PhantomData,
+        }),
+        Box::new(CounterTarget {
+            idx: 1,
+            counter: counter.clone(),
+            _s: PhantomData,
+        }),
+        Box::new(CounterTarget {
+            idx: 2,
+            counter: counter.clone(),
+            _s: PhantomData,
+        }),
+    ];
+
+    let config = StreamMuxConfiguration {
+        stream: tokio_stream::iter(0..10u32),
+        stop_processing_target_on_failure: true,
+        targets,
+        callback: DummyCallback,
+    };
+
+    let muxer = mux_stream(config, None)
+        .await
+        .expect("Failed to start mutiplexer");
+
+    // The muxer should die after the stream ends, signifying the test is over
+    periodic_check(
+        || muxer.get_status() == ActorStatus::Stopped,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(30, counter.load(Ordering::Relaxed));
+}
+
+// ================= Failing Targets ================= //
+
+struct GoodTarget;
+
+impl<S> Target<S> for GoodTarget
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+{
+    fn get_id(&self) -> String {
+        "good".to_string()
+    }
+
+    fn message_received(&self, _: <S as Stream>::Item) -> Result<(), ActorProcessingErr> {
+        Ok(())
+    }
+}
+
+struct BadTarget;
+
+impl<S> Target<S> for BadTarget
+where
+    S: Stream + ractor::State,
+    S::Item: Clone + ractor::Message,
+{
+    fn get_id(&self) -> String {
+        "bad".to_string()
+    }
+
+    fn message_received(&self, _: <S as Stream>::Item) -> Result<(), ActorProcessingErr> {
+        Err(From::from("boom"))
+    }
+}
+
+struct CountingCallback {
+    fail_counter: Arc<AtomicU32>,
+    eos_counter: Arc<AtomicU32>,
+}
+
+impl StreamMuxNotification for CountingCallback {
+    fn target_failed(&self, _target: String, _err: ActorProcessingErr) {
+        self.fail_counter.fetch_add(1, Ordering::Relaxed);
+    }
+    fn end_of_stream(&self) {
+        self.eos_counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[ractor::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_mux_failed_targets() {
+    let fail_counter = Arc::new(AtomicU32::new(0));
+    let eos_counter = Arc::new(AtomicU32::new(0));
+
+    let targets: Vec<Box<dyn Target<Iter<std::ops::Range<u32>>>>> =
+        vec![Box::new(GoodTarget), Box::new(BadTarget)];
+
+    let config = StreamMuxConfiguration {
+        stream: tokio_stream::iter(0..10u32),
+        stop_processing_target_on_failure: true,
+        targets,
+        callback: CountingCallback {
+            fail_counter: fail_counter.clone(),
+            eos_counter: eos_counter.clone(),
+        },
+    };
+
+    let muxer = mux_stream(config, None)
+        .await
+        .expect("Failed to start mutiplexer");
+
+    // wait for muxer to stop
+    periodic_check(
+        || muxer.get_status() == ActorStatus::Stopped,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(1, fail_counter.load(Ordering::Relaxed));
+    assert_eq!(1, eos_counter.load(Ordering::Relaxed));
+}
+
+#[ractor::concurrency::test]
+#[tracing_test::traced_test]
+async fn test_mux_failed_targets_no_removal() {
+    let fail_counter = Arc::new(AtomicU32::new(0));
+    let eos_counter = Arc::new(AtomicU32::new(0));
+
+    let targets: Vec<Box<dyn Target<Iter<std::ops::Range<u32>>>>> =
+        vec![Box::new(GoodTarget), Box::new(BadTarget)];
+
+    let config = StreamMuxConfiguration {
+        stream: tokio_stream::iter(0..10u32),
+        stop_processing_target_on_failure: false,
+        targets,
+        callback: CountingCallback {
+            fail_counter: fail_counter.clone(),
+            eos_counter: eos_counter.clone(),
+        },
+    };
+
+    let muxer = mux_stream(config, None)
+        .await
+        .expect("Failed to start mutiplexer");
+
+    // wait for muxer to stop
+    periodic_check(
+        || muxer.get_status() == ActorStatus::Stopped,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    assert_eq!(10, fail_counter.load(Ordering::Relaxed));
+    assert_eq!(1, eos_counter.load(Ordering::Relaxed));
+}

--- a/ractor_actors/src/streams/pump/mod.rs
+++ b/ractor_actors/src/streams/pump/mod.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+//! ## Processing a stream
+//!
+//! If you want to process a stream which emits records that should
+//! be forwarded to an actor for processing, you can utilize [spawn_stream_pump]
+//! to create an actor which will specifically process a stream of messages and
+//! convert them to messages for an actor, pushing them into the actor's message queue.
+//!
+//! We specifically don't expose the internals of how the stream pump actor is created,
+//! but still support monitoring the actor by returning an [ActorCell] which represents
+//! the underlying actor, and can be used for pattern matching on supervision events.
+
+use std::marker::PhantomData;
+use std::pin::Pin;
+
+use ractor::cast;
+use ractor::ActorCell;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+use ractor::SpawnErr;
+use tokio_stream::Stream;
+use tokio_stream::StreamExt;
+
+use crate::streams::{spawn_loop, IterationResult, Operation};
+
+#[cfg(test)]
+mod tests;
+
+struct StreamerState<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    stream: Pin<Box<S>>,
+    fn_map: F,
+    who: ActorRef<T>,
+}
+
+struct Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    _s: PhantomData<S>,
+    _t: PhantomData<T>,
+    _f: PhantomData<F>,
+}
+
+// SAFETY: The types here are all phantom data markers, and do not impact
+// the requirement for streamer to be Sync
+unsafe impl<S, T, F> Sync for Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+}
+
+#[ractor::async_trait]
+impl<S, T, F> Operation for Streamer<S, T, F>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    type State = StreamerState<S, T, F>;
+
+    async fn work(&self, state: &mut Self::State) -> Result<IterationResult, ActorProcessingErr> {
+        // fetch the next item and check if it's the last item
+        let item = state.stream.next().await;
+        let last = item.is_none();
+
+        tracing::trace!("Streamer forwarding item: last {last}");
+
+        cast!(state.who, (state.fn_map)(item))?;
+
+        let signal = if last {
+            IterationResult::End
+        } else {
+            IterationResult::Continue
+        };
+        Ok(signal)
+    }
+}
+
+/// Process a stream of information, pumping messages received to a receipient
+///
+/// * `stream`: The stream of `Item`s to process
+/// * `receiver`: The actor who will receive outputs from the stream
+/// * `fn_map`: Mapping function to convert a `S::Item` to the input message for the recipient actor.
+/// In the event the stream type is a sub-value of the message enum of the actor, this can be used
+/// to map to the right sub-message type
+/// * `supervisor`: (Optional) If the receiver is **not** the supervisor, a separate supervisor can be
+/// provided here
+///
+/// Returns the [ActorCell] for the underlying stream pump actor upon successful startup, or a [SpawnErr] if the
+/// underlying actor failed to spawn.
+pub async fn spawn_stream_pump<S, T, F>(
+    stream: S,
+    receiver: ActorRef<T>,
+    fn_map: F,
+    supervisor: Option<ActorCell>,
+) -> Result<ActorCell, SpawnErr>
+where
+    S: Stream + ractor::State,
+    T: ractor::Message,
+    F: Fn(Option<<S as Stream>::Item>) -> T + ractor::State,
+{
+    let sup = supervisor.unwrap_or_else(|| receiver.get_cell());
+
+    let pumper = Streamer::<S, T, F> {
+        _s: PhantomData,
+        _t: PhantomData,
+        _f: PhantomData,
+    };
+    let pump_state = StreamerState::<S, T, F> {
+        fn_map,
+        who: receiver,
+        stream: Box::pin(stream),
+    };
+
+    spawn_loop(pumper, pump_state, Some(sup)).await
+}

--- a/ractor_actors/src/streams/tests.rs
+++ b/ractor_actors/src/streams/tests.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Sean Lawlor
+//
+// This source code is licensed under both the MIT license found in the
+// LICENSE-MIT file in the root directory of this source tree.
+
+use ractor::call;
+use ractor::concurrency::{sleep, Duration};
+use ractor::Actor;
+use ractor::ActorProcessingErr;
+use ractor::ActorRef;
+use ractor::RpcReplyPort;
+use tokio_stream as stream;
+
+use super::spawn_stream_pump;
+
+struct StreamActor;
+
+enum StreamActorMessage {
+    GetCount(RpcReplyPort<u64>),
+    Add(u64),
+}
+
+#[ractor::async_trait]
+impl Actor for StreamActor {
+    type Msg = StreamActorMessage;
+    type State = u64;
+    type Arguments = ();
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        _: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        // just for the test, drop the cell
+        let _ = spawn_stream_pump(
+            stream::iter(1u64..=500u64),
+            myself.clone(),
+            |a| {
+                if a.is_some() {
+                    StreamActorMessage::Add(1)
+                } else {
+                    StreamActorMessage::Add(0)
+                }
+            },
+            None,
+        )
+        .await?;
+
+        Ok(0)
+    }
+
+    async fn handle(
+        &self,
+        _: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            StreamActorMessage::GetCount(reply) => {
+                println!("Received count request");
+                let _ = reply.send(*state);
+            }
+            StreamActorMessage::Add(i) => {
+                *state += i;
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        _message: ractor::SupervisionEvent,
+        _state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        // ignore child fails (stream exits)
+        Ok(())
+    }
+}
+
+#[ractor::concurrency::test]
+async fn test_streaming_operation() {
+    // Setup
+    // Create the actor
+    let (actor, handle) = Actor::spawn(None, StreamActor, ())
+        .await
+        .expect("Failed to spawn non-blocking actor tree");
+
+    // Allow the background blocking operation some time to increment the parent's counter
+    sleep(Duration::from_millis(100)).await;
+
+    // Assert
+
+    // Get the count
+    let reply = call!(actor, StreamActorMessage::GetCount).expect("Failed to get count");
+    assert!(reply >= 1);
+
+    // Cleanup
+    actor.stop(None);
+    handle.await.unwrap();
+}


### PR DESCRIPTION
This PR adds 3 types of stream-like processing actors

1. Looped operations: Responsible for operations that should continue processing forever or until some final condition (like a stream of items)
2. Stream processing actor, which reads a stream and converts them to actionable messages for a downstream source (i.e. send message to actor)
3. A stream mux actor which takes in a stream of cloneable items, and sends it to a collection of downstream targets.

More to come :)