### PR TITLE
Adds support for having the actors be built using the async_trait crate or native async fn's in traits.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,9 @@ jobs:
           - name: Run the default tests
             package: ractor_actors
             # flags: 
+          - name: Run the default tests with async-trait based actors
+            package: ractor_actors
+            flags: -F async-trait
             
     steps:
       - uses: actions/checkout@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "ractor_actors",

--- a/ractor_actors/Cargo.toml
+++ b/ractor_actors/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ractor_actors"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Sean Lawlor"]
 description = "Helpful actors built with Ractor"
 documentation = "https://docs.rs/ractor_actors"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 keywords = ["actor", "ractor"]
 repository = "https://github.com/slawlor/ractor"
 readme = "../README.md"
@@ -15,18 +15,20 @@ categories = ["asynchronous"]
 [features]
 filewatcher = ["notify"]
 net = ["tokio/net", "tokio/io-util", "tokio/macros", "tokio-rustls"]
-time = ["chrono", "cron"]
-streams = ["tokio-stream"]
+time = ["chrono", "cron", "dep:async-trait"]
+streams = ["tokio-stream", "dep:async-trait"]
 sync = []
+async-trait = ["dep:async-trait", "ractor/async-trait"]
 
 default = ["filewatcher", "net", "time", "streams", "sync"]
 
 [dependencies]
 # Required dependencies
-ractor = { version = "0.14", features = ["async-trait"] }
+ractor = { version = "0.14" }
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1"
 # Feature-specific dependencies
+async-trait = { version = "0.1", optional = true }
 chrono = { version = "0.4", optional = true }
 cron = { version = "0.12", optional = true }
 tokio-stream = { version = "0.1", optional = true }

--- a/ractor_actors/examples/cron.rs
+++ b/ractor_actors/examples/cron.rs
@@ -17,7 +17,6 @@ use std::str::FromStr;
 
 use cron::Schedule;
 use ractor::{
-    async_trait,
     concurrency::{sleep, Duration, Instant},
     Actor, ActorProcessingErr,
 };
@@ -27,7 +26,7 @@ struct MyJob {
     last: Option<Instant>,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl Job for MyJob {
     fn id<'a>(&self) -> &'a str {
         "my_job"

--- a/ractor_actors/src/filewatcher/mod.rs
+++ b/ractor_actors/src/filewatcher/mod.rs
@@ -70,7 +70,7 @@ pub struct FileWatcherState {
     subscriptions: HashMap<ActorId, Box<dyn FileWatcherSubscriber>>,
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for FileWatcher {
     type Msg = FileWatcherMessage;
     type State = FileWatcherState;

--- a/ractor_actors/src/net/tcp/listener.rs
+++ b/ractor_actors/src/net/tcp/listener.rs
@@ -18,7 +18,7 @@ pub struct Listener<R>
 where
     R: SessionAcceptor,
 {
-    _r: PhantomData<R>,
+    _r: PhantomData<fn() -> R>,
 }
 
 impl<R> Default for Listener<R>
@@ -65,7 +65,7 @@ where
 
 pub struct ListenerMessage;
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl<R> Actor for Listener<R>
 where
     R: SessionAcceptor,

--- a/ractor_actors/src/net/tcp/mod.rs
+++ b/ractor_actors/src/net/tcp/mod.rs
@@ -92,16 +92,32 @@ pub enum IncomingEncryptionMode {
 }
 
 /// Represents a receiver of frames of data
-#[ractor::async_trait]
-pub trait FrameReceiver: Send + Sync + 'static {
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
+pub trait FrameReceiver: ractor::State {
     /// Called when a frame is received by the [TcpSession] actor
+    #[cfg(not(feature = "async-trait"))]
+    fn frame_ready(
+        &self,
+        f: Frame,
+    ) -> impl std::future::Future<Output = Result<(), ActorProcessingErr>> + Send;
+
+    /// Called when a frame is received by the [TcpSession] actor
+    #[cfg(feature = "async-trait")]
     async fn frame_ready(&self, f: Frame) -> Result<(), ActorProcessingErr>;
 }
 
 /// Represents
-#[ractor::async_trait]
-pub trait SessionAcceptor: Send + Sync + 'static {
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
+pub trait SessionAcceptor: ractor::State {
     /// Called when a new incoming session is received by a `TcpListener` actor
+    #[cfg(not(feature = "async-trait"))]
+    fn new_session(
+        &self,
+        session: NetworkStream,
+    ) -> impl std::future::Future<Output = Result<(), ActorProcessingErr>> + Send;
+
+    /// Called when a new incoming session is received by a `TcpListener` actor
+    #[cfg(feature = "async-trait")]
     async fn new_session(&self, session: NetworkStream) -> Result<(), ActorProcessingErr>;
 }
 

--- a/ractor_actors/src/net/tcp/session.rs
+++ b/ractor_actors/src/net/tcp/session.rs
@@ -51,7 +51,7 @@ pub struct TcpSession<R>
 where
     R: FrameReceiver,
 {
-    _r: PhantomData<R>,
+    _r: PhantomData<fn() -> R>,
 }
 
 impl<R> Default for TcpSession<R>
@@ -73,7 +73,7 @@ where
     }
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl<R> Actor for TcpSession<R>
 where
     R: FrameReceiver,
@@ -301,7 +301,7 @@ enum SessionWriterMessage {
     Write(Frame),
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for SessionWriter {
     type Msg = SessionWriterMessage;
     type Arguments = ActorWriteHalf;
@@ -384,7 +384,7 @@ struct SessionReaderState {
     reader: Option<ActorReadHalf>,
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for SessionReader {
     type Msg = SessionReaderMessage;
     type Arguments = ActorReadHalf;

--- a/ractor_actors/src/streams/looping/mod.rs
+++ b/ractor_actors/src/streams/looping/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! struct SampleOperation;
 //!
-//! #[ractor::async_trait]
+//! #[async_trait::async_trait]
 //! impl Operation for SampleOperation {
 //!     type State = ();
 //!
@@ -58,7 +58,7 @@ pub enum IterationResult {
 /// either (a) shutdown ([IterationResult::End]) or (b) error. This could be processing a stream
 /// request or some continuous polling operation (something like a configuration element,
 /// which emits signals when the config changes)
-#[ractor::async_trait]
+#[async_trait::async_trait]
 pub trait Operation: ractor::State + Sync {
     /// The state of the looping operation. It is bound to the internal actor's [Actor::State]
     /// but doesn't require specifying all of the inner actor properties
@@ -76,14 +76,10 @@ struct Loop<T>
 where
     T: Operation,
 {
-    _t: PhantomData<T>,
+    _t: PhantomData<fn() -> T>,
 }
 
-// SAFETY: `T` is only present as PhantomData, so it doesn't actually affect if the
-// [LoopActor] is Sync across thread boundaries.
-unsafe impl<T> Sync for Loop<T> where T: Operation {}
-
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl<TOperation> Actor for Loop<TOperation>
 where
     TOperation: Operation,

--- a/ractor_actors/src/streams/looping/tests.rs
+++ b/ractor_actors/src/streams/looping/tests.rs
@@ -13,7 +13,7 @@ use crate::common_test::periodic_async_check;
 
 struct BackgroundAdder;
 
-#[ractor::async_trait]
+#[async_trait::async_trait]
 impl Operation for BackgroundAdder {
     type State = ActorRef<TestBedMessage>;
 
@@ -31,7 +31,7 @@ enum TestBedMessage {
     Add(u64),
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for TestBedActor {
     type Msg = TestBedMessage;
     type State = u64;

--- a/ractor_actors/src/streams/mux/mod.rs
+++ b/ractor_actors/src/streams/mux/mod.rs
@@ -149,7 +149,7 @@ where
 {
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl<S, N> Actor for MuxActor<S, N>
 where
     S: Stream + ractor::State,

--- a/ractor_actors/src/streams/pump/mod.rs
+++ b/ractor_actors/src/streams/pump/mod.rs
@@ -62,7 +62,7 @@ where
 {
 }
 
-#[ractor::async_trait]
+#[async_trait::async_trait]
 impl<S, T, F> Operation for Streamer<S, T, F>
 where
     S: Stream + ractor::State,

--- a/ractor_actors/src/streams/pump/tests.rs
+++ b/ractor_actors/src/streams/pump/tests.rs
@@ -22,7 +22,7 @@ enum StreamActorMessage {
     Add(u64),
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for StreamActor {
     type Msg = StreamActorMessage;
     type State = u64;

--- a/ractor_actors/src/sync/broadcast/mod.rs
+++ b/ractor_actors/src/sync/broadcast/mod.rs
@@ -143,7 +143,7 @@ where
     continue_with_dead_targets: bool,
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl<T> Actor for Broadcaster<T>
 where
     T: ractor::Message + Clone,

--- a/ractor_actors/src/sync/broadcast/tests.rs
+++ b/ractor_actors/src/sync/broadcast/tests.rs
@@ -16,7 +16,7 @@ use super::*;
 type TestMessage = u32;
 
 struct HappyActor;
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for HappyActor {
     type Msg = TestMessage;
     type State = Arc<AtomicU32>;
@@ -42,7 +42,7 @@ impl Actor for HappyActor {
 }
 
 struct BoomActor;
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for BoomActor {
     type Msg = TestMessage;
     type State = Arc<AtomicU32>;

--- a/ractor_actors/src/time/cron/mod.rs
+++ b/ractor_actors/src/time/cron/mod.rs
@@ -19,12 +19,12 @@
 //! use std::time::Duration;
 //!
 //! use cron::Schedule;
-//! use ractor::{async_trait, Actor, ActorProcessingErr};
+//! use ractor::{Actor, ActorProcessingErr};
 //! use ractor_actors::time::cron::*;
 //!
 //! struct SomeJob;
 //!
-//! #[async_trait]
+//! #[async_trait::async_trait]
 //! impl Job for SomeJob {
 //!     fn id<'a>(&self) -> &'a str {
 //!         "some_job"
@@ -78,7 +78,7 @@ use worker::{Cron, CronMessage};
 ///
 /// If the job takes longer than the period, queueing may occur and the
 /// job may violate scheduling
-#[ractor::async_trait]
+#[async_trait::async_trait]
 pub trait Job: State {
     /// Retrieve the name of the cron job for logging
     fn id<'a>(&self) -> &'a str;
@@ -137,7 +137,7 @@ pub enum CronManagerMessage {
     Unsubscribe(ActorId),
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for CronManager {
     type Msg = CronManagerMessage;
     type State = CronManagerState;
@@ -304,7 +304,7 @@ mod tests {
     use super::*;
 
     struct BadJob;
-    #[ractor::async_trait]
+    #[async_trait::async_trait]
     impl Job for BadJob {
         fn id<'a>(&self) -> &'a str {
             "bad_job"
@@ -318,7 +318,7 @@ mod tests {
     struct CounterJob {
         counter: Arc<AtomicU16>,
     }
-    #[ractor::async_trait]
+    #[async_trait::async_trait]
     impl Job for CounterJob {
         fn id<'a>(&self) -> &'a str {
             "counter_job"

--- a/ractor_actors/src/time/cron/worker.rs
+++ b/ractor_actors/src/time/cron/worker.rs
@@ -37,7 +37,7 @@ pub enum CronMessage {
     UpdateSchedule(Schedule),
 }
 
-#[ractor::async_trait]
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 impl Actor for Cron {
     type Msg = CronMessage;
     type State = CronState;
@@ -127,7 +127,7 @@ mod tests {
         counter: Arc<AtomicU16>,
     }
 
-    #[ractor::async_trait]
+    #[async_trait::async_trait]
     impl Job for TestJob {
         fn id<'a>(&self) -> &'a str {
             "test_job"


### PR DESCRIPTION
This adds a new feature which can be opted in to utilize `async_trait` in the actor implementations (depending on how you use ractor).

`async_trait` is still a required dependency in some contexts however due to the usage of `dyn Trait` with async fn's.

CI tests updated to run the suite in both async-trait and non async-trait profiles