### PR TITLE
Fix "watchdog" feature to work with ractor 0.15.7+

### DIFF
--- a/ractor_actors/Cargo.toml
+++ b/ractor_actors/Cargo.toml
@@ -25,7 +25,7 @@ default = ["filewatcher", "net", "time", "streams", "sync", "watchdog"]
 
 [dependencies]
 # Required dependencies
-ractor = { version = "0.15" }
+ractor = { version = "0.15.8" }
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1"
 # Feature-specific dependencies

--- a/ractor_actors/src/watchdog/mod.rs
+++ b/ractor_actors/src/watchdog/mod.rs
@@ -169,6 +169,7 @@ async fn cast(msg: WatchdogMsg) -> Result<(), MessagingErr<()>> {
 
 async fn call<TReply, TMsgBuilder>(msg_builder: TMsgBuilder) -> Result<TReply, MessagingErr<()>>
 where
+    TReply: Send + 'static,
     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> WatchdogMsg,
 {
     match WATCHDOG.get_or_init(spawn).await {


### PR DESCRIPTION
The signature of `ractor::actor::actor_ref::ActorRef::call` changed in ractor 0.15.7 which breaks this crate.

- https://docs.rs/ractor/0.15.6/ractor/actor/actor_ref/struct.ActorRef.html#method.call
- https://docs.rs/ractor/0.15.7/ractor/actor/actor_ref/struct.ActorRef.html#method.call

```console
error[E0277]: `TReply` cannot be sent between threads safely
   --> ractor_actors/src/watchdog/mod.rs:176:14
    |
176 |             .call(msg_builder, None)
    |              ^^^^ `TReply` cannot be sent between threads safely
    |
note: required by a bound in `rpc::<impl ActorRef<TMessage>>::call`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ractor-0.15.12/src/rpc.rs:336:17
    |
329 |     pub async fn call<TReply, TMsgBuilder>(
    |                  ---- required by a bound in this associated function
...
336 |         TReply: Send + 'static,
    |                 ^^^^ required by this bound in `rpc::<impl ActorRef<TMessage>>::call`
help: consider further restricting type parameter `TReply` with trait `Send`
    |
172 |     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> WatchdogMsg, TReply: std::marker::Send
    |                                                               +++++++++++++++++++++++++

error[E0277]: `TReply` cannot be sent between threads safely
   --> ractor_actors/src/watchdog/mod.rs:175:31
    |
175 |           Ok(watchdog) => match watchdog
    |  _______________________________^
176 | |             .call(msg_builder, None)
    | |____________________________________^ `TReply` cannot be sent between threads safely
    |
note: required by a bound in `rpc::<impl ActorRef<TMessage>>::call`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ractor-0.15.12/src/rpc.rs:336:17
    |
329 |     pub async fn call<TReply, TMsgBuilder>(
    |                  ---- required by a bound in this associated function
...
336 |         TReply: Send + 'static,
    |                 ^^^^ required by this bound in `rpc::<impl ActorRef<TMessage>>::call`
help: consider further restricting type parameter `TReply` with trait `Send`
    |
172 |     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> WatchdogMsg, TReply: std::marker::Send
    |                                                               +++++++++++++++++++++++++

error[E0277]: `TReply` cannot be sent between threads safely
   --> ractor_actors/src/watchdog/mod.rs:177:14
    |
177 |             .await
    |              ^^^^^ `TReply` cannot be sent between threads safely
    |
note: required by a bound in `rpc::<impl ActorRef<TMessage>>::call`
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/ractor-0.15.12/src/rpc.rs:336:17
    |
329 |     pub async fn call<TReply, TMsgBuilder>(
    |                  ---- required by a bound in this associated function
...
336 |         TReply: Send + 'static,
    |                 ^^^^ required by this bound in `rpc::<impl ActorRef<TMessage>>::call`
help: consider further restricting type parameter `TReply` with trait `Send`
    |
172 |     TMsgBuilder: FnOnce(RpcReplyPort<TReply>) -> WatchdogMsg, TReply: std::marker::Send
    |                                                               +++++++++++++++++++++++++
```