### PR TITLE
Support range of cron versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,10 @@ jobs:
         include:
           - name: Run the default tests
             package: ractor_actors
-            # flags: 
+            flags: -F cron-0-16
           - name: Run the default tests with async-trait based actors
             package: ractor_actors
-            flags: -F async-trait
+            flags: -F cron-0-16 -F async-trait
             
     steps:
       - uses: actions/checkout@main
@@ -40,6 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -F cron-0-16
 
   clippy:
     name: Clippy
@@ -114,4 +115,3 @@ jobs:
   #       with:
   #         command: bench
   #         args: --no-run
-          

--- a/ractor_actors/Cargo.toml
+++ b/ractor_actors/Cargo.toml
@@ -15,7 +15,12 @@ categories = ["asynchronous"]
 [features]
 filewatcher = ["notify"]
 net = ["tokio/net", "tokio/io-util", "tokio/macros", "tokio-rustls"]
-time = ["chrono", "cron", "dep:async-trait"]
+time = ["cron-0-12"] # deprecated
+cron-0-12 = ["dep:async-trait", "dep:chrono", "dep:cron-0-12"]
+cron-0-13 = ["dep:async-trait", "dep:chrono", "dep:cron-0-13"]
+cron-0-14 = ["dep:async-trait", "dep:chrono", "dep:cron-0-14"]
+cron-0-15 = ["dep:async-trait", "dep:chrono", "dep:cron-0-15"]
+cron-0-16 = ["dep:async-trait", "dep:chrono", "dep:cron-0-16"]
 streams = ["tokio-stream", "dep:async-trait"]
 sync = []
 watchdog = []
@@ -31,7 +36,11 @@ tracing = "0.1"
 # Feature-specific dependencies
 async-trait = { version = "0.1", optional = true }
 chrono = { version = "0.4", optional = true }
-cron = { version = "0.12", optional = true }
+cron-0-12 = { package = "cron", version = "0.12", optional = true }
+cron-0-13 = { package = "cron", version = "0.13", optional = true }
+cron-0-14 = { package = "cron", version = "0.14", optional = true }
+cron-0-15 = { package = "cron", version = "0.15", optional = true }
+cron-0-16 = { package = "cron", version = "0.16", optional = true }
 tokio-stream = { version = "0.1", optional = true }
 notify = { version = "8", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
@@ -43,5 +52,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-test = "0.2"
 
 [[example]]
+name = "cron"
+required-features = ["cron-0-16"]
+
+[[example]]
 name = "tcp_client"
 required-features = ["tokio/io-std", "watchdog"]
+
+[package.metadata.docs.rs]
+features = ["cron-0-12", "cron-0-13", "cron-0-14", "cron-0-15", "cron-0-16"]

--- a/ractor_actors/examples/cron.rs
+++ b/ractor_actors/examples/cron.rs
@@ -15,12 +15,12 @@
 extern crate ractor_actors;
 use std::str::FromStr;
 
-use cron::Schedule;
+use cron_0_16::Schedule;
 use ractor::{
     concurrency::{sleep, Duration, Instant},
     Actor, ActorProcessingErr,
 };
-use ractor_actors::time::cron::{CronManager, CronManagerMessage, CronSettings, Job};
+use ractor_actors::time::cron_0_16::{CronManager, CronManagerMessage, CronSettings, Job};
 
 struct MyJob {
     last: Option<Instant>,

--- a/ractor_actors/src/lib.rs
+++ b/ractor_actors/src/lib.rs
@@ -34,13 +34,21 @@
 //! ```
 //!
 
+#![cfg_attr(test, allow(deprecated))]
+
 #[cfg(feature = "filewatcher")]
 pub mod filewatcher;
 
 #[cfg(feature = "net")]
 pub mod net;
 
-#[cfg(feature = "time")]
+#[cfg(any(
+    feature = "cron-0-12",
+    feature = "cron-0-13",
+    feature = "cron-0-14",
+    feature = "cron-0-15",
+    feature = "cron-0-16",
+))]
 pub mod time;
 
 #[cfg(feature = "streams")]

--- a/ractor_actors/src/time/cron/common.rs
+++ b/ractor_actors/src/time/cron/common.rs
@@ -1,0 +1,30 @@
+use ractor::{ActorProcessingErr, State};
+
+/// Represents a job managed by a cron schedule. Executes on a
+/// given period and may take an unknown amount of time.
+///
+/// If the job takes longer than the period, queueing may occur and the
+/// job may violate scheduling
+#[async_trait::async_trait]
+pub trait Job: State {
+    /// Retrieve the name of the cron job for logging
+    fn id<'a>(&self) -> &'a str;
+
+    /// Execute the work, taking a mutable reference to the object
+    async fn work(&mut self) -> Result<(), ActorProcessingErr>;
+}
+
+/// Represents a dynamic subscription to [CronManager] events which
+/// denote cron job startup/failure/stoppage
+///
+/// [CronManager]: crate::time::cron_0_16::CronManager
+pub trait CronEventSubscriber: State {
+    /// A job started
+    fn started(&self, job: String);
+
+    /// A job was stopped, with the optional stop reason
+    fn stopped(&self, job: String, reason: Option<String>);
+
+    /// A job failed, including the failure reason
+    fn failed(&self, job: String, reason: String);
+}

--- a/ractor_actors/src/time/cron/mod.rs
+++ b/ractor_actors/src/time/cron/mod.rs
@@ -18,9 +18,9 @@
 //! use std::str::FromStr;
 //! use std::time::Duration;
 //!
-//! use cron::Schedule;
+//! use cron_0_16::Schedule;
 //! use ractor::{Actor, ActorProcessingErr};
-//! use ractor_actors::time::cron::*;
+//! use ractor_actors::time::cron_0_16::*;
 //!
 //! struct SomeJob;
 //!
@@ -67,38 +67,12 @@
 
 use std::collections::HashMap;
 
-use cron::Schedule;
-use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, State, SupervisionEvent};
+use super::cron_crate::Schedule;
+use super::{CronEventSubscriber, Job};
+use ractor::{Actor, ActorId, ActorProcessingErr, ActorRef, RpcReplyPort, SupervisionEvent};
 
 mod worker;
 use worker::{Cron, CronMessage};
-
-/// Represents a job managed by a cron schedule. Executes on a
-/// given period and may take an unknown amount of time.
-///
-/// If the job takes longer than the period, queueing may occur and the
-/// job may violate scheduling
-#[async_trait::async_trait]
-pub trait Job: State {
-    /// Retrieve the name of the cron job for logging
-    fn id<'a>(&self) -> &'a str;
-
-    /// Execute the work, taking a mutable reference to the object
-    async fn work(&mut self) -> Result<(), ActorProcessingErr>;
-}
-
-/// Represents a dynamic subscription to [CronManager] events which
-/// denote cron job startup/failure/stoppage
-pub trait CronEventSubscriber: State {
-    /// A job started
-    fn started(&self, job: String);
-
-    /// A job was stopped, with the optional stop reason
-    fn stopped(&self, job: String, reason: Option<String>);
-
-    /// A job failed, including the failure reason
-    fn failed(&self, job: String, reason: String);
-}
 
 /// The settings for a singular cron job
 pub struct CronSettings {

--- a/ractor_actors/src/time/cron/worker.rs
+++ b/ractor_actors/src/time/cron/worker.rs
@@ -5,8 +5,8 @@
 
 //! Cron-job actor for scheduling periodic jobs
 
+use super::super::cron_crate::Schedule;
 use chrono::Utc;
-use cron::Schedule;
 use ractor::{concurrency::JoinHandle, Actor, ActorProcessingErr, ActorRef, MessagingErr};
 
 use super::{CronSettings, Job};

--- a/ractor_actors/src/time/mod.rs
+++ b/ractor_actors/src/time/mod.rs
@@ -5,4 +5,67 @@
 
 //! Time/timer related functionality built on [ractor]
 
-pub mod cron;
+#![allow(clippy::duplicate_mod)]
+
+#[path = "cron/common.rs"]
+mod cron_common;
+
+#[cfg(feature = "time")]
+#[deprecated = "Use \"cron-0-12\" feature (or a newer one) rather than \"time\""]
+pub mod cron {
+    use cron_0_12 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}
+
+#[cfg(feature = "cron-0-12")]
+#[path = "cron"]
+pub mod cron_0_12 {
+    use cron_0_12 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}
+
+#[cfg(feature = "cron-0-13")]
+#[path = "cron"]
+pub mod cron_0_13 {
+    use cron_0_13 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}
+
+#[cfg(feature = "cron-0-14")]
+#[path = "cron"]
+pub mod cron_0_14 {
+    use cron_0_14 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}
+
+#[cfg(feature = "cron-0-15")]
+#[path = "cron"]
+pub mod cron_0_15 {
+    use cron_0_15 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}
+
+#[cfg(feature = "cron-0-16")]
+#[path = "cron"]
+pub mod cron_0_16 {
+    use cron_0_16 as cron_crate;
+    #[path = "mod.rs"]
+    mod cron_impl;
+    pub use self::cron_impl::*;
+    pub use super::cron_common::*;
+}


### PR DESCRIPTION
The "time" feature is currently only compatible with a very outdated version of the `cron` crate.

`cron` has a faster release cadence than `ractor_actors`. `cron` has released incompatible versions 0.12.1, 0.13, 0.14, 0.15, 0.16 all in the time that `ractor_actors` has been on 0.4.x. If `ractor_actors` is going to support only a single `cron` version per version of `ractor_actors`, then `ractor_actors` needs to start doing a faster major version release cadence to keep up. Otherwise, to handle multiple different `cron` versions in the same release of `ractor_actors`, this PR is the way to do it.