### PR TITLE
Suppress large_enum_variant clippy lint on CronMessage

### DIFF
--- a/ractor_actors/src/time/cron/worker.rs
+++ b/ractor_actors/src/time/cron/worker.rs
@@ -32,6 +32,7 @@ impl CronState {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum CronMessage {
     Execute,
     UpdateSchedule(Schedule),


### PR DESCRIPTION
Noticed in https://github.com/slawlor/ractor_actors/actions/runs/23595415764/job/68710757622. This seems unimportant for this type.

```console
warning: large size difference between variants
  --> ractor_actors/src/time/cron/worker.rs:35:1
   |
35 | / pub enum CronMessage {
36 | |     Execute,
   | |     ------- the second-largest variant carries no data at all
37 | |     UpdateSchedule(Schedule),
   | |     ------------------------ the largest variant contains at least 248 bytes
38 | | }
   | |_^ the entire enum is at least 248 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields or introducing indirection in some other way to reduce the total size of the enum
   |
37 -     UpdateSchedule(Schedule),
37 +     UpdateSchedule(Box<Schedule>),
   |
```